### PR TITLE
Add shared frontend types and integrate in UI

### DIFF
--- a/frontend/src/lib/components/StockForm.svelte
+++ b/frontend/src/lib/components/StockForm.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import {
+    INVALID_SYMBOL,
+    PAST_DATE,
+    type StockFormFields,
+    type ValidationErrors,
+    type FormProps,
+    type ErrorEvent,
+  } from "../../../../src/types";
+
+  export let onSubmit: FormProps["onSubmit"];
+
+  const dispatch = createEventDispatcher<ErrorEvent>();
+
+  let fields: StockFormFields = {
+    symbol: "",
+    startDate: "",
+    endDate: "",
+  };
+
+  let errors: ValidationErrors = {};
+
+  function validate(): ValidationErrors {
+    const result: ValidationErrors = {};
+    if (!fields.symbol) {
+      result.symbol = INVALID_SYMBOL;
+    }
+    if (fields.startDate && new Date(fields.startDate) < new Date()) {
+      result.startDate = PAST_DATE;
+    }
+    return result;
+  }
+
+  async function handleSubmit() {
+    errors = validate();
+    if (Object.keys(errors).length === 0) {
+      try {
+        await onSubmit(fields);
+      } catch (error) {
+        dispatch("error", { error: error as any });
+      }
+    }
+  }
+</script>
+
+<form on:submit|preventDefault={handleSubmit}>
+  <label>
+    Symbol
+    <input bind:value={fields.symbol} />
+    {#if errors.symbol}
+      <span class="error">{errors.symbol}</span>
+    {/if}
+  </label>
+  <label>
+    Start Date
+    <input type="date" bind:value={fields.startDate} />
+    {#if errors.startDate}
+      <span class="error">{errors.startDate}</span>
+    {/if}
+  </label>
+  <label>
+    End Date
+    <input type="date" bind:value={fields.endDate} />
+  </label>
+  <button type="submit">Predict</button>
+</form>

--- a/frontend/src/lib/components/index.ts
+++ b/frontend/src/lib/components/index.ts
@@ -1,2 +1,1 @@
-// Component exports will be added here
-export {};
+export { default as StockForm } from "./StockForm.svelte";

--- a/frontend/src/lib/services/index.ts
+++ b/frontend/src/lib/services/index.ts
@@ -1,2 +1,1 @@
-// Service layer exports will be added here
-export {};
+export { fetchPrediction } from "./prediction";

--- a/frontend/src/lib/services/prediction.ts
+++ b/frontend/src/lib/services/prediction.ts
@@ -1,0 +1,40 @@
+import type {
+  PredictionResult,
+  ProgressUpdate,
+  ApiError,
+  StockFormFields,
+} from "../../../../src/types";
+
+/**
+ * Fetch a prediction from the backend API
+ */
+export async function fetchPrediction(
+  fields: StockFormFields,
+  onProgress?: (update: ProgressUpdate) => void,
+): Promise<PredictionResult> {
+  try {
+    onProgress?.({ message: "Requesting prediction", progress: 0 });
+    const response = await fetch("/api/predict", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(fields),
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw {
+        message,
+        statusCode: response.status,
+        code: response.statusText,
+      } as ApiError;
+    }
+
+    onProgress?.({ message: "Prediction received", progress: 1 });
+    return (await response.json()) as PredictionResult;
+  } catch (err) {
+    const error: ApiError =
+      err && typeof err === "object" ? (err as ApiError) : { message: String(err) };
+    onProgress?.({ message: "Prediction failed", progress: 1 });
+    throw error;
+  }
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
-	// Placeholder for main page component
+  import { StockForm } from "$lib/components";
+  import { fetchPrediction } from "$lib/services";
+  import type { StockFormFields, PredictionResult } from "../../../src/types";
+
+  let result: PredictionResult | null = null;
+
+  async function handleSubmit(fields: StockFormFields) {
+    result = await fetchPrediction(fields, (p) => console.log(p));
+  }
 </script>
 
 <h1>Stock Prediction Interface</h1>
-<p>Welcome to the stock prediction frontend!</p>
+<StockForm onSubmit={handleSubmit} on:error={(e) => console.error(e.detail.error)} />
+{#if result}
+  <pre>{JSON.stringify(result, null, 2)}</pre>
+{/if}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,7 +12,7 @@ import {
 import { ChartService } from "../services/chartService";
 import { DataService } from "../services/dataService";
 import { PredictionService } from "../services/predictionService";
-import { ApiError } from "../types";
+import type { ApiError } from "../types";
 
 /**
  * Express.js API server for stock price prediction
@@ -713,13 +713,19 @@ export class ApiServer {
         console.error("API Error:", error);
 
         // Handle known API errors
-        if (error instanceof ApiError) {
-          res.status(error.statusCode).json({
+        if (
+          error &&
+          typeof error === "object" &&
+          "statusCode" in error &&
+          typeof (error as ApiError).statusCode === "number"
+        ) {
+          const apiError = error as ApiError;
+          res.status(apiError.statusCode).json({
             success: false,
             error: {
-              code: error.code,
-              message: error.message,
-              details: error.details,
+              code: apiError.code,
+              message: apiError.message,
+              details: apiError.details,
             },
           });
           return;

--- a/src/types/frontend.ts
+++ b/src/types/frontend.ts
@@ -1,0 +1,101 @@
+/**
+ * Frontend progress update events for long-running operations
+ */
+export interface ProgressUpdate {
+  /** Human readable description of current step */
+  message: string;
+  /** Progress percentage from 0-1 */
+  progress: number;
+}
+
+/**
+ * Standard API error shape used on the frontend
+ */
+export interface ApiError {
+  /** Error message for display */
+  message: string;
+  /** HTTP status code if available */
+  statusCode?: number;
+  /** Machine readable error code */
+  code?: string;
+  /** Additional error details */
+  details?: unknown;
+}
+
+/**
+ * Form fields for requesting stock predictions
+ */
+export interface StockFormFields {
+  /** Stock ticker symbol */
+  symbol: string;
+  /** ISO string start date */
+  startDate: string;
+  /** ISO string end date */
+  endDate: string;
+}
+
+/**
+ * Validation error messages keyed by field name
+ */
+export type ValidationErrors = Partial<Record<keyof StockFormFields, string>>;
+
+/** Error message when an invalid stock symbol is provided */
+export const INVALID_SYMBOL = "Invalid stock symbol";
+
+/** Error message when a date lies in the past */
+export const PAST_DATE = "Date cannot be in the past";
+
+/**
+ * Props for form-like components that submit stock fields
+ */
+export interface FormProps {
+  onSubmit: (fields: StockFormFields) => void | Promise<void>;
+}
+
+/**
+ * Svelte event dispatched on errors from form components
+ */
+export interface ErrorEvent {
+  error: ApiError;
+}
+
+/**
+ * Individual prediction scenario (conservative, bullish, or bearish)
+ */
+export interface PredictionScenario {
+  targetPrice: number;
+  timeframe: string;
+  probability: number;
+  factors: string[];
+}
+
+/**
+ * Enhanced prediction scenario with confidence intervals
+ */
+export interface EnhancedPredictionScenario extends PredictionScenario {
+  confidenceInterval: [number, number];
+  standardError: number;
+}
+
+/**
+ * Model accuracy and performance metrics
+ */
+export interface AccuracyMetrics {
+  rSquared: number;
+  rmse: number;
+  mape: number;
+  confidenceInterval: [number, number];
+}
+
+/**
+ * Complete prediction result with all three scenarios
+ */
+export interface PredictionResult {
+  symbol: string;
+  conservative: EnhancedPredictionScenario;
+  bullish: EnhancedPredictionScenario;
+  bearish: EnhancedPredictionScenario;
+  accuracy: AccuracyMetrics;
+  confidence: number;
+  timestamp: Date;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -257,24 +257,14 @@ export interface ApiResponse<T> {
     | undefined;
 }
 
-/**
- * Custom API error class
- */
-export class ApiError extends Error {
-  public statusCode: number;
-  public code: string;
-  public details?: any;
+// Frontend-specific types
+export type {
+  ProgressUpdate,
+  ApiError,
+  StockFormFields,
+  ValidationErrors,
+  FormProps,
+  ErrorEvent,
+} from "./frontend";
 
-  constructor(
-    message: string,
-    statusCode: number = 500,
-    code: string = "API_ERROR",
-    details?: any
-  ) {
-    super(message);
-    this.name = "ApiError";
-    this.statusCode = statusCode;
-    this.code = code;
-    this.details = details;
-  }
-}
+export { INVALID_SYMBOL, PAST_DATE } from "./frontend";


### PR DESCRIPTION
## Summary
- add frontend-facing type definitions for API responses, progress updates, and stock form validation
- expose new types from shared types module and update API error handling
- implement Svelte stock form and prediction service using shared types

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5ab7b01c4832283f4d244ab6fa853